### PR TITLE
downgrade ubuntu to 20.04

### DIFF
--- a/.github/workflows/buildAndDeploy.yaml
+++ b/.github/workflows/buildAndDeploy.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build Docker Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check Out
@@ -43,7 +43,7 @@ jobs:
   terraform:
     name: Terraform Apply
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: production
 
     defaults:


### PR DESCRIPTION
downgrade ubuntu to 20.04 as the runner for 22.04 in github actions takes too long
[documentation](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/)